### PR TITLE
Add CI workflow with lint, test, and build steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npm run lint
+      - run: npm test
+      - run: npm run build


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run install, lint, test, and build on pushes and pull requests

## Testing
- `npm install`
- `npm run lint` *(fails: Missing script "lint")*
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc5a6346048323835964b773e417c9